### PR TITLE
Fix #1215: Sort admin conference dashboard by latest first

### DIFF
--- a/client/src/conferencemodule/Tabs/ConferencePage.jsx
+++ b/client/src/conferencemodule/Tabs/ConferencePage.jsx
@@ -160,8 +160,10 @@ const ConferencePage = () => {
                             </Tr>
                         </Thead>
                         <Tbody>
-                            {data.length > 0 ? (data.map((item) => (
-                                <Tr key={item._id}>
+                            {data.length > 0 ? (data
+                                .sort((a, b) => b._id.localeCompare(a._id))
+                                .map((item) => (
+                                    <Tr key={item._id}>
                                     <Td><Center>{item.name}</Center></Td>
                                     <Td><Center>{item.email}</Center></Td>
                                     <Td><Center>


### PR DESCRIPTION
This PR resolves issue #1215
I added a .sort() function using the MongoDB _id field to ensure the latest conferences appear at the top