### PR TITLE
Uncommenting Faculty Timetable Change Email Sender

### DIFF
--- a/server/src/modules/timetableModule/controllers/locktimetable.js
+++ b/server/src/modules/timetableModule/controllers/locktimetable.js
@@ -177,7 +177,7 @@ async function sendFacultyChangeEmails(facultyChanges) {
     }
 
     try {
-      // await mailSender(facultyDoc.email, emailTitle, emailBody(facultyDoc._id.toString()));
+      await mailSender(facultyDoc.email, emailTitle, emailBody(facultyDoc._id.toString()));
       console.log(`Email sent to: ${facultyDoc.email}`);
       console.log(facultyDoc._id);
 


### PR DESCRIPTION
Uncomment the faculty timetable change email sender to ensure faculty members receive email alerts for any timetable updates.